### PR TITLE
fix 404 to Rookout docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Great! You're now ready to start debugging, let's start by having some fun with 
 ## License
 [APACHE 2](LICENSE)
 
-[rookout-getting-started]: https://docs.rookout.com/docs/introduction.html
+[rookout-getting-started]: https://docs.rookout.com/
 [rookout-signup]: https://www.rookout.com/trial/
 [license-url]: LICENSE
 [docs-image]: https://img.shields.io/badge/docs-latest-blue.svg


### PR DESCRIPTION
The link to the Rookout docs in the Readme.md points at an introduction page in the Rookout docs that does not exist anymore.

Maybe there would be somewhere specific you want it to point to, but I've changed I've just changed the URL to https://docs.rookout.com/ which redirects to a specific welcome page.