### PR TITLE
RK-10340 - removed libffi6 apt install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ references:
     run:
       command: |
         mkdir -p ~/.ssh/ && echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
-        sudo apt update && sudo apt-get install python3 python3-setuptools python3-dev build-essential libpq-dev libffi6 libffi-dev libssl-dev python3-pip
+        sudo apt update && sudo apt-get install python3 python3-setuptools python3-dev build-essential libpq-dev libffi-dev libssl-dev python3-pip
         python3 -m pip install --upgrade --user setuptools six
         git clone git@github.com:Rookout/build_tools.git
         python3 -m pip install -r build_tools/requirements.txt --user


### PR DESCRIPTION
CircleCI fails with "Unable to locate package libffi6".
Looks like libffi7 is already installed and there's no need for the apt.