### PR TITLE
RK-12296 - Updated Jaeger to 3.3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ dependencies {
 
     compile("org.yaml:snakeyaml:1.26")
     // tracing support
-    compile group: 'io.opentracing.contrib', name: 'opentracing-spring-jaeger-web-starter', version: '3.1.2'
+    compile group: 'io.opentracing.contrib', name: 'opentracing-spring-jaeger-web-starter', version: '3.3.1'
     
     testCompile('org.springframework.boot:spring-boot-starter-test')
     testCompile('org.springframework.restdocs:spring-restdocs-mockmvc')


### PR DESCRIPTION
Running this project either in docker or manually does not work and throws an exception. Updating the `opentracing-spring-jaeger-web-starter` dependency seem to solve it.