### PR TITLE
RK-13145 - update deprecated circleci images, due to missing public key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
 
   checkout_code_upver:
     docker:
-      - image: circleci/openjdk:8-jdk-browsers
+      - image: cimg/openjdk:8.0-browsers
     working_directory: ~/demo
     steps:
       - *checkout_default_wd
@@ -82,7 +82,7 @@ jobs:
 
   build_and_push_demo_image:
     docker:
-      - image: circleci/openjdk:8-jdk-browsers
+      - image: cimg/openjdk:8.0-browsers
     working_directory: ~/demo
     steps:
       - *load_cache
@@ -132,7 +132,7 @@ jobs:
 
   notify_slack:
     docker:
-        - image: circleci/openjdk:8-jdk-browsers
+        - image: cimg/openjdk:8.0-browsers
     working_directory: ~/demo
     steps:
       - *setup_build_tools


### PR DESCRIPTION
See build failure here - https://app.circleci.com/pipelines/github/Rookout/tutorial-java/291/workflows/59974bab-afed-4df3-9798-f46eeae664d1/jobs/1076

I'm assuming the deprecated image doesn't have updated keys.
In case you need an update about circleci images - https://circleci.com/docs/circleci-images